### PR TITLE
Add a variable for specifying http_listen_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ This role only installs loki. For promtail, see [this role](https://github.com/p
 This role is compatible with any modern systemd-based distro.  
 
 ## Role Variables
-| Variable name                | Default value | Description                                        |
-| ---------------------------- | ------------- | -------------------------------------------------- |
-| loki_version                 | `1.4.1`       | version of loki                                    |
-| loki_system_user             | `loki`        | user for running loki                              |
-| loki_system_group            | `loki`        | group for running loki                             |
-| loki_server_http_listen_port | `3100`        | listen port for loki                               |
-| loki_directories             | `{}`          | array of directories to create before running loki |
-| loki_schema_config           | default dict  | YAML with schema config                            |
-| loki_storage_config          | default dict  | YAML with storage config                           |
-| loki_ingester                | default dict  | YAML with ingester settings                        |
-| loki_limits_config           | default dict  | YAML with limits settings                          |
-| loki_chunk_store_config      | default dict  | YAML with chuck store settings                     |
-| loki_table_manager           | default dict  | YAML with table manager settings                   |
+| Variable name                   | Default value | Description                                        |
+| ------------------------------- | ------------- | -------------------------------------------------- |
+| loki_version                    | `1.4.1`       | version of loki                                    |
+| loki_system_user                | `loki`        | user for running loki                              |
+| loki_system_group               | `loki`        | group for running loki                             |
+| loki_server_http_listen_port    | `3100`        | listen port for loki                               |
+| loki_server_http_listen_address | `localhost`   | listen address for loki                            |
+| loki_directories                | `{}`          | array of directories to create before running loki |
+| loki_schema_config              | default dict  | YAML with schema config                            |
+| loki_storage_config             | default dict  | YAML with storage config                           |
+| loki_ingester                   | default dict  | YAML with ingester settings                        |
+| loki_limits_config              | default dict  | YAML with limits settings                          |
+| loki_chunk_store_config         | default dict  | YAML with chuck store settings                     |
+| loki_table_manager              | default dict  | YAML with table manager settings                   |
 
 ## Settings
 To configure loki with role you just need to supply YAML to each corresponding block. See example configs from loki github repo for examples.   

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ loki_system_user: loki
 loki_system_group: loki
 loki_auth_enabled: false
 loki_server_http_listen_port: 3100
+loki_server_http_listen_address: localhost
 loki_directories: []
 loki_schema_config:
   - from: 2018-04-15

--- a/templates/loki.yml.j2
+++ b/templates/loki.yml.j2
@@ -3,6 +3,7 @@ auth_enabled: {{ loki_auth_enabled | bool | lower }}
 
 server:
   http_listen_port: {{ loki_server_http_listen_port }}
+  http_listen_address: {{ loki_server_http_listen_address }}
 
 ingester:
   {{ loki_ingester | to_nice_yaml(indent=2) | indent(2, False) }}


### PR DESCRIPTION
The variable is named loki_server_http_listen_address, in order to match loki_server_http_listen_port.
I set localhost as the default for the variable, for safety reasons, as it is more restrictive than 0.0.0.0.
One should note that this would change the current default behavior, which is to listen for 0.0.0.0.
I think it is better to be restrictive by default, please tell me if it should be changed.

This closes #1.